### PR TITLE
add check options to .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,14 @@ Checks: >
      -readability-magic-numbers,
      -readability-static-accessed-through-instance,
 
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase, value: lower_case }
+  - { key: readability-identifier-naming.MethodCase, value: lower_case }
+  - { key: readability-identifier-naming.FunctionCase, value: lower_case }
+  - { key: readability-identifier-naming.ParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.StructCase, value: lower_case }
+  - { key: readability-identifier-naming.VariableCase, value: lower_case }
+
 HeaderFilterRegex: ".*"
 
 WarningsAsErrors: "*"


### PR DESCRIPTION
CheckOptions is added to code analyzer file as #25 