### PR TITLE
Operator unit test functions added.

### DIFF
--- a/include/rvstd/bool_and_vec/interval_set.hpp
+++ b/include/rvstd/bool_and_vec/interval_set.hpp
@@ -6,6 +6,9 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <cstdlib>
+#include <typeinfo>
+#include <new>
 
 namespace rvstd
 {
@@ -19,17 +22,10 @@ namespace rvstd
          bool init;
 
       public:
-         using size_type = int;
+         using size_type = std::size_t;
 
-         interval_set( std::initializer_list< std::pair< TypeT, TypeT > > common_ )
+         interval_set( std::initializer_list< std::pair< TypeT, TypeT > > common_, bool init_ = false )
          {
-            if( common_.begin()->first == (TypeT)0 ) {
-               init = true;
-            }
-            else {
-               init = false;
-            }
-
             for( std::pair< TypeT, TypeT > p : common_ ) {
                if( p.first > p.second ) {
                   throw std::invalid_argument( "invalid interval" );
@@ -50,13 +46,13 @@ namespace rvstd
             }
          }
 
-         explicit interval_set(){};
+         explicit interval_set() {};
 
          ~interval_set() = default;
          interval_set( interval_set&& ) noexcept = default;
          interval_set& operator=( interval_set&& ) noexcept = default;
-         interval_set( const interval_set& ) = delete;
-         interval_set& operator=( const interval_set& ) = delete;
+         interval_set( const interval_set& ) = default;
+         interval_set& operator=( const interval_set& ) = default;
 
          void reserve( size_type n )
          {
@@ -76,7 +72,9 @@ namespace rvstd
             return data.empty();
          };
 
-         AllocatorT get_allocator_type() const noexcept;  // returns the type of allocator.
+         std::string get_allocator_type() const noexcept {
+            return (std::string)(typeid(AllocatorT).name);
+         };  // returns the type of allocator.
 
          bool contains( const std::pair< TypeT, TypeT >& ) noexcept;
 
@@ -87,23 +85,25 @@ namespace rvstd
 
          void append( const std::pair< TypeT, TypeT > ){};  // adds an interval to end of the list
 
-         bool at( const TypeT ) noexcept
-         {
+         bool at( const TypeT ) {
             return false;
          };  // returns value at a spesific time
 
-         interval_set< TypeT, AllocatorT >& set_union( const interval_set& other );
-         interval_set< TypeT, AllocatorT >& set_difference( const interval_set& other );
-         interval_set< TypeT, AllocatorT >& set_intersection( const interval_set& other );
+         interval_set< TypeT, AllocatorT >& set_union( const interval_set< TypeT, AllocatorT >& other );
+         interval_set< TypeT, AllocatorT >& set_difference( const interval_set< TypeT, AllocatorT >& other );
+         interval_set< TypeT, AllocatorT >& set_intersection( const interval_set< TypeT, AllocatorT >& other );
          interval_set< TypeT, AllocatorT >& set_complement();
 
-         interval_set< TypeT, AllocatorT >& operator+( const interval_set& other );
-         interval_set< TypeT, AllocatorT >& operator-( const interval_set& other );
-         interval_set< TypeT, AllocatorT >& operator&( const interval_set& other );
-         interval_set< TypeT, AllocatorT >& operator not();
+         interval_set< TypeT, AllocatorT > operator+( const interval_set< TypeT, AllocatorT >& other ) {return *this;}
+         interval_set< TypeT, AllocatorT > operator-( const interval_set< TypeT, AllocatorT >& other ) {return *this;}
+         interval_set< TypeT, AllocatorT > operator&( const interval_set< TypeT, AllocatorT >& other ) {return *this;}
+         interval_set< TypeT, AllocatorT > operator not() {return *this;}
 
          // UTILITY
          std::string to_string() noexcept;
+         std::vector< TypeT >& get_data_vector() { return data; }
+         bool get_init() { return init; }
+
       };
    }  // namespace bool_and_vec
 }  // namespace rvstd

--- a/tests/bool_and_vec.cpp
+++ b/tests/bool_and_vec.cpp
@@ -165,3 +165,216 @@ TEST_CASE( "appending one interval to the set " )
       // is0 -> { 2, 7, 15, 22 } { T, F, T, F }
    }
 }
+
+TEST_CASE( "Union operation" ) {
+   ns::interval_set< int > is1 { { { 1, 3 }, { 9, 11 } }, false };
+   ns::interval_set< int > is2 { { { 5, 7 } }, false };
+   ns::interval_set< int > is3 { { { 1, 2 } }, false };
+   ns::interval_set< int > is4 { { { 1, 14 } }, false };
+   ns::interval_set< int > is5 { { { 2, 4 } }, false };
+   ns::interval_set< int > is6 { { { 2, 10 } }, false };
+
+   SECTION("Union with non-intersecting sets") {
+      ns::interval_set< int > true_val { {1, 3}, {5, 7}, {9, 11} };
+      auto test_val = is1 + is2;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Union with two overlapping sets") {
+      ns::interval_set< int > true_val { {1, 3}, {9, 11} };
+      auto test_val = is1 + is3;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Union with completely encapsulating set") {
+      ns::interval_set< int > true_val { {1, 14} };
+      auto test_val = is1 + is4;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Union with partially overlapped set") {
+      ns::interval_set< int > true_val { {1, 4}, {9, 11} };
+      auto test_val = is1 + is5;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Union with partially encapsulating set") {
+      ns::interval_set< int > true_val { {1, 11} };
+      auto test_val = is1 + is6;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+}
+
+TEST_CASE( "Intersection operation" ) {
+
+   ns::interval_set< int > is1 { { { 2, 7 }, { 15, 21 } }, false };
+   ns::interval_set< int > is2 { { { 3, 4 } }, false };
+   ns::interval_set< int > is3 { { { 3, 4 }, { 16, 20 } }, false };
+   ns::interval_set< int > is4 { { { 2, 7 } }, false };
+   ns::interval_set< int > is5 { { { 2, 7 }, { 15, 21 } }, false };
+   ns::interval_set< int > is6 { { { 5, 18 } }, false };
+   ns::interval_set< int > is7 { { { 8, 10 } }, false };
+   ns::interval_set< int > is8 { { { 7, 15 } }, false };
+   ns::interval_set< int > is9 { { { 2, 21 } }, false };
+   ns::interval_set< int > is10 { { { 1, 22 } }, false };
+
+   SECTION("Intersection on one part") {
+      ns::interval_set< int > true_val { {3, 4} };
+      auto test_val = is1 & is2;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Intersection on two parts") {
+      ns::interval_set< int > true_val { {3, 4}, {16, 20} };
+      auto test_val = is1 & is3;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Intersection on one part completely") {
+      ns::interval_set< int > true_val { {2, 7} };
+      auto test_val = is1 & is4;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Intersection of two parts completely") {
+      ns::interval_set< int > true_val { {2, 7}, {15, 21} };
+      auto test_val = is1 & is5;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Partially intersection with one consecutive interval") {
+      ns::interval_set< int > true_val { {5, 7}, {15, 18} };
+      auto test_val = is1 & is6;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Intersection with two separate sets") {
+      ns::interval_set< int > true_val {};
+      auto test_val = is1 & is7;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Intersection with two separate sets boundaries") {
+      ns::interval_set< int > true_val {};
+      auto test_val = is1 & is8;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Intersection with completely surjective set boundaries") {
+      ns::interval_set< int > true_val { {2, 7}, {15, 21} };
+      auto test_val = is1 & is9;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Intersection with completely surjective set") {
+      ns::interval_set< int > true_val { {2, 7}, {15, 21} };
+      auto test_val = is1 & is10;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+}
+
+TEST_CASE( "Difference operation" ) {
+
+   ns::interval_set< int > is1 { { { 2, 7 }, { 15, 21 } }, false };
+   ns::interval_set< int > is2 { { { 3, 4 } }, false };
+   ns::interval_set< int > is3 { { { 3, 4 }, { 16, 20 } }, false };
+   ns::interval_set< int > is4 { { { 2, 7 } }, false };
+   ns::interval_set< int > is5 { { { 2, 7 }, { 15, 21 } }, false };
+   ns::interval_set< int > is6 { { { 5, 18 } }, false };
+   ns::interval_set< int > is7 { { { 8, 10 } }, false };
+   ns::interval_set< int > is8 { { { 7, 15 } }, false };
+   ns::interval_set< int > is9 { { { 2, 21 } }, false };
+   ns::interval_set< int > is10 { { { 1, 22 } }, false };
+
+   SECTION("Difference inside one part") {
+      ns::interval_set< int > true_val { {2, 3}, {4, 7}, {15, 21} };
+      auto test_val = is1 - is2;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Difference inside two parts") {
+      ns::interval_set< int > true_val { {2, 3}, {4, 7}, {15, 16}, {20, 21} };
+      auto test_val = is1 - is3;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Difference of one part completely") {
+      ns::interval_set< int > true_val { {15, 21} };
+      auto test_val = is1 - is4;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Difference of two parts completely") {
+      ns::interval_set< int > true_val {};
+      auto test_val = is1 - is5;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Partially difference with one consecutive interval") {
+      ns::interval_set< int > true_val { {2, 5}, {18, 21} };
+      auto test_val = is1 - is6;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Difference with two separate sets") {
+      ns::interval_set< int > true_val { {2, 7}, {15, 21} };
+      auto test_val = is1 - is7;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Difference with two separate sets boundaries") {
+      ns::interval_set< int > true_val { {2, 7}, {15, 21} };
+      auto test_val = is1 - is8;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Difference with completely surjective set boundaries") {
+      ns::interval_set< int > true_val {};
+      auto test_val = is1 - is9;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+   SECTION("Difference with completely surjective set") {
+      ns::interval_set< int > true_val {};
+      auto test_val = is1 - is10;
+      CHECK( test_val.get_data_vector() == true_val.get_data_vector() );
+      CHECK( test_val.get_init() == true_val.get_init() );
+   }
+
+}
+
+TEST_CASE("NOT operation") {
+   ns::interval_set< int > test_val { {10, 20}, {35, 45},{46, 50} };
+   CHECK((not(test_val).get_init()) == !(test_val.get_init()));
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
Unit tests are extended to control operator functions.

To gain more speed while developing the copy constructor and assignment is activated. Their reaction is changed from delete to default.

Unit tests are aimed to test corner cases.

Other changes:

* size type is changed to std::size_t to gain portability.
* One argument constructor was inadequate, to denote all signals correctly I added another parameter which is for signal starting parameter.
* Reference parameters are deleted, we are mainly testing our cases to work correctly, not on speed aspect right now.

